### PR TITLE
Change to Python 3

### DIFF
--- a/README.html
+++ b/README.html
@@ -231,18 +231,18 @@ cells. This can be done very easily with:</p>
 choose one for us. Since all elements are integers, numpy will then choose an
 integer data type. This can be easily checked using:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z.dtype
+&gt;&gt;&gt; print(Z.dtype)
 int64
 </pre>
 <p>We can also check the shape of the array to make sure it is 6x6:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z.shape
+&gt;&gt;&gt; print(Z.shape)
 (6, 6)
 </pre>
 <p>Each element of <tt class="docutils literal">Z</tt> can be accessed using a <tt class="docutils literal">row</tt> and a <tt class="docutils literal">column</tt>
 index (in that order):</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z[0,5]
+&gt;&gt;&gt; print(Z[0,5])
 0
 </pre>
 <div class="note">
@@ -253,7 +253,7 @@ is very powerful tool for vectorized computation.</p>
 <p>But even better, we can also access a subpart of the array using the slice
 notation:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z[1:5,1:5]
+&gt;&gt;&gt; print(Z[1:5,1:5])
 [[0 0 1 0]
  [1 0 1 0]
  [0 1 1 0]
@@ -267,14 +267,14 @@ have immediate impact on <tt class="docutils literal">Z</tt>:</p>
 <pre class="doctest-block">
 &gt;&gt;&gt; A = Z[1:5,1:5]
 &gt;&gt;&gt; A[0,0] = 9
-&gt;&gt;&gt; print A
+&gt;&gt;&gt; print(A)
 [[9 0 1 0]
  [1 0 1 0]
  [0 1 1 0]
  [0 0 0 0]]
 </pre>
 <pre class="doctest-block">
-&gt;&gt;&gt; print Z
+&gt;&gt;&gt; print(Z)
 [[0 0 0 0 0 0]
  [0 9 0 1 0 0]
  [0 1 0 1 0 0]
@@ -289,9 +289,9 @@ with such simple arrays, but things can become much more complex (we'll see
 that later). If in doubt, you can check easily if an array is part of another
 one:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z.base is None
+&gt;&gt;&gt; print(Z.base is None)
 True
-&gt;&gt;&gt; print A.base is Z
+&gt;&gt;&gt; print(A.base is Z)
 True
 </pre>
 <div class="section" id="counting-neighbours">
@@ -310,7 +310,7 @@ is called <em>vectorization</em>.</p>
 <p>First, you need to know that you can manipulate <tt class="docutils literal">Z</tt> <em>as if</em> (and only <em>as
 if</em>) it was a regular scalar:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print 1+(2*Z+3)
+&gt;&gt;&gt; print(1+(2*Z+3))
 [[4 4 4 4 4 4]
  [4 4 4 6 4 4]
  [4 6 4 6 4 4]
@@ -336,7 +336,7 @@ the impossibility of <em>broadcasting</em> the two arrays together. <a class="re
 a very powerful feature of numpy and most of the time, it saves you a lot of
 hassle.  Let's consider for example the following code:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z+1
+&gt;&gt;&gt; print(Z+1)
 [[1 1 1 1 1 1]
  [1 1 1 2 1 1]
  [1 2 1 2 1 1]
@@ -457,7 +457,7 @@ to check). We then set all <tt class="docutils literal">Z</tt> values to 0 (all 
 the <tt class="docutils literal">birth</tt> and <tt class="docutils literal">survive</tt> arrays to conditionally set <tt class="docutils literal">Z</tt> values
 to 1. And we're done ! Let's test this:</p>
 <pre class="literal-block">
-&gt;&gt;&gt; print Z
+&gt;&gt;&gt; print(Z)
 [[0 0 0 0 0 0]
  [0 0 0 1 0 0]
  [0 1 0 1 0 0]
@@ -465,7 +465,7 @@ to 1. And we're done ! Let's test this:</p>
  [0 0 0 0 0 0]
  [0 0 0 0 0 0]]
 &gt;&gt;&gt; for i in range(4): iterate_2(Z)
-&gt;&gt;&gt; print Z
+&gt;&gt;&gt; print(Z)
 [[0 0 0 0 0 0]
  [0 0 0 0 0 0]
  [0 0 0 0 1 0]
@@ -562,7 +562,7 @@ single array. Numpy allows to do that with the notion of <a class="reference ext
 &gt;&gt;&gt; n = 200
 &gt;&gt;&gt; Z = np.zeros((n+2,n+2), [('U', np.double),
                              ('V', np.double)])
-&gt;&gt;&gt; print Z.dtype
+&gt;&gt;&gt; print(Z.dtype)
 [('U', '&lt;f8'), ('V', '&lt;f8')]
 </pre>
 <p>The size of the array is (n+2,n+2) since we need the borders when computing the

--- a/README.html
+++ b/README.html
@@ -582,7 +582,7 @@ def laplacian(Z):
 </pre>
 <p>Finally, we can iterate the computation after havong choosed some interesting parameters:</p>
 <pre class="literal-block">
-for i in xrange(25000):
+for i in range(25000):
     Lu = laplacian(U)
     Lv = laplacian(V)
     uvv = u*v*v

--- a/README.html
+++ b/README.html
@@ -144,7 +144,7 @@ move one step diagonally in 4 iterations as illustrated below:</p>
 <h2>The way of python</h2>
 <div class="note">
 <p class="first admonition-title">Note</p>
-<p class="last">We could have used the more efficient <a class="reference external" href="http://docs.python.org/2/library/array.html">python array interface</a> but people may be more
+<p class="last">We could have used the more efficient <a class="reference external" href="https://docs.python.org/3/library/array.html">python array interface</a> but people may be more
 familiar with the list object.</p>
 </div>
 <p>In pure python, we can code the Game of Life using a list of lists representing

--- a/README.rst
+++ b/README.rst
@@ -231,18 +231,18 @@ choose one for us. Since all elements are integers, numpy will then choose an
 integer data type. This can be easily checked using::
 
 
-  >>> print Z.dtype
+  >>> print(Z.dtype)
   int64
 
 We can also check the shape of the array to make sure it is 6x6::
 
-  >>> print Z.shape
+  >>> print(Z.shape)
   (6, 6)
 
 Each element of ``Z`` can be accessed using a ``row`` and a ``column``
 index (in that order)::
 
-  >>> print Z[0,5]
+  >>> print(Z[0,5])
   0
 
 .. note:: 
@@ -254,7 +254,7 @@ index (in that order)::
 But even better, we can also access a subpart of the array using the slice
 notation::
 
-  >>> print Z[1:5,1:5]
+  >>> print(Z[1:5,1:5])
   [[0 0 1 0]
    [1 0 1 0]
    [0 1 1 0]
@@ -268,13 +268,13 @@ have immediate impact on ``Z``:
 
   >>> A = Z[1:5,1:5]
   >>> A[0,0] = 9
-  >>> print A
+  >>> print(A)
   [[9 0 1 0]
    [1 0 1 0]
    [0 1 1 0]
    [0 0 0 0]]
   
-  >>> print Z
+  >>> print(Z)
   [[0 0 0 0 0 0]
    [0 9 0 1 0 0]
    [0 1 0 1 0 0]
@@ -288,9 +288,9 @@ with such simple arrays, but things can become much more complex (we'll see
 that later). If in doubt, you can check easily if an array is part of another
 one::
 
-  >>> print Z.base is None
+  >>> print(Z.base is None)
   True
-  >>> print A.base is Z
+  >>> print(A.base is Z)
   True
 
 
@@ -315,7 +315,7 @@ Ok, let's start then...
 First, you need to know that you can manipulate ``Z`` *as if* (and only *as
 if*) it was a regular scalar::
 
- >>> print 1+(2*Z+3)
+ >>> print(1+(2*Z+3))
  [[4 4 4 4 4 4]
   [4 4 4 6 4 4]
   [4 6 4 6 4 4]
@@ -340,7 +340,7 @@ the impossibility of *broadcasting* the two arrays together. `Broadcasting`_ is
 a very powerful feature of numpy and most of the time, it saves you a lot of
 hassle.  Let's consider for example the following code::
 
-  >>> print Z+1
+  >>> print(Z+1)
   [[1 1 1 1 1 1]
    [1 1 1 2 1 1]
    [1 2 1 2 1 1]
@@ -458,7 +458,7 @@ to check). We then set all ``Z`` values to 0 (all cells become dead) and we use
 the ``birth`` and ``survive`` arrays to conditionally set ``Z`` values
 to 1. And we're done ! Let's test this::
 
-  >>> print Z
+  >>> print(Z)
   [[0 0 0 0 0 0]
    [0 0 0 1 0 0]
    [0 1 0 1 0 0]
@@ -466,7 +466,7 @@ to 1. And we're done ! Let's test this::
    [0 0 0 0 0 0]
    [0 0 0 0 0 0]]
   >>> for i in range(4): iterate_2(Z)
-  >>> print Z
+  >>> print(Z)
   [[0 0 0 0 0 0]
    [0 0 0 0 0 0]
    [0 0 0 0 1 0]
@@ -571,7 +571,7 @@ single array. Numpy allows to do that with the notion of `structured array
   >>> n = 200
   >>> Z = np.zeros((n+2,n+2), [('U', np.double),
                                ('V', np.double)])
-  >>> print Z.dtype
+  >>> print(Z.dtype)
   [('U', '<f8'), ('V', '<f8')]
 
 The size of the array is (n+2,n+2) since we need the borders when computing the
@@ -628,7 +628,7 @@ Neophyte
    .. code:: python
       :class: solution
 
-      print np.__version__
+      print(np.__version__)
       np.__config__.show()
 
 
@@ -678,7 +678,7 @@ Neophyte
    .. code:: python
       :class: solution   
 
-      print np.nonzero([1,2,0,0,4,0])
+      print(np.nonzero([1,2,0,0,4,0]))
 
 
 8. Declare a 3x3 identity matrix
@@ -849,12 +849,12 @@ Apprentice
       :class: solution   
 
       for dtype in [np.int8, np.int32, np.int64]:
-         print np.iinfo(dtype).min
-         print np.iinfo(dtype).max
+         print(np.iinfo(dtype).min)
+         print(np.iinfo(dtype).max)
       for dtype in [np.float32, np.float64]:
-         print np.finfo(dtype).min
-         print np.finfo(dtype).max
-         print np.finfo(dtype).eps
+         print(np.finfo(dtype).min)
+         print(np.finfo(dtype).max)
+         print(np.finfo(dtype).eps)
 
 
 5. Create a structured array representing a position (x,y) and a color (r,g,b)

--- a/README.rst
+++ b/README.rst
@@ -133,7 +133,7 @@ The way of python
 .. note:: 
 
    We could have used the more efficient `python array interface
-   <http://docs.python.org/2/library/array.html>`_ but people may be more
+   <https://docs.python.org/3/library/array.html>`_ but people may be more
    familiar with the list object.
 
 

--- a/README.rst
+++ b/README.rst
@@ -592,7 +592,7 @@ obtained via the `finite difference method
 
 Finally, we can iterate the computation after havong choosed some interesting parameters::
 
-  for i in xrange(25000):
+  for i in range(25000):
       Lu = laplacian(U)
       Lv = laplacian(V)
       uvv = u*v*v

--- a/scripts/exercice-1.py
+++ b/scripts/exercice-1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 import numpy as np

--- a/scripts/exercice-1.py
+++ b/scripts/exercice-1.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/scripts/exercice-2.py
+++ b/scripts/exercice-2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 import numpy as np

--- a/scripts/exercice-2.py
+++ b/scripts/exercice-2.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/scripts/exercice-3.py
+++ b/scripts/exercice-3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 import numpy as np

--- a/scripts/exercice-3.py
+++ b/scripts/exercice-3.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/scripts/exercice-4.py
+++ b/scripts/exercice-4.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''
 Reaction Diffusion : Gray-Scott model

--- a/scripts/exercice-4.py
+++ b/scripts/exercice-4.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 Reaction Diffusion : Gray-Scott model
 

--- a/scripts/exercice-4.py
+++ b/scripts/exercice-4.py
@@ -30,7 +30,7 @@ fig.add_axes([0.0, 0.0, 1.0, 1.0], frameon=False)
 im = plt.imshow(Z, interpolation='bicubic', cmap=plt.cm.hot)
 plt.xticks([]), plt.yticks([])
 
-for i in xrange(50000):
+for i in range(50000):
     L = (                 Z[0:-2,1:-1] +
          Z[1:-1,0:-2] - 4*Z[1:-1,1:-1] + Z[1:-1,2:] +
                           Z[2:  ,1:-1] )

--- a/scripts/game-of-life-big.py
+++ b/scripts/game-of-life-big.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA
 # Contributors: Nicolas P. Rougier (Nicolas.Rougier@inria.fr)

--- a/scripts/game-of-life-big.py
+++ b/scripts/game-of-life-big.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA

--- a/scripts/game-of-life-numpy.py
+++ b/scripts/game-of-life-numpy.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA
 # Contributors: Nicolas P. Rougier (Nicolas.Rougier@inria.fr)

--- a/scripts/game-of-life-numpy.py
+++ b/scripts/game-of-life-numpy.py
@@ -79,8 +79,8 @@ Z = np.array([[0,0,0,0,0,0],
               [0,0,0,0,0,0],
               [0,0,0,0,0,0]])
 
-print Z
-print
+print(Z)
+print()
 for i in range(4): iterate_2(Z)
-print Z
+print(Z)
 

--- a/scripts/game-of-life-numpy.py
+++ b/scripts/game-of-life-numpy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA

--- a/scripts/game-of-life-python.py
+++ b/scripts/game-of-life-python.py
@@ -17,8 +17,8 @@ def compute_neighbours(Z):
 
 def show(Z):
     for l in Z[1:-1]:
-        print l[1:-1]
-    print
+        print(l[1:-1])
+    print()
 
 def iterate(Z):
     shape = len(Z), len(Z[0])

--- a/scripts/glider-trace.py
+++ b/scripts/glider-trace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 import numpy as np

--- a/scripts/glider-trace.py
+++ b/scripts/glider-trace.py
@@ -18,7 +18,7 @@ def iterate(Z):
     Z[1:-1,1:-1][birth | survive] = 1
     return Z
 
-Z  = np.random.randint(0,2,(256,512)).astype(int)
+Z  = np.random.randint(0,2,(256,256)).astype(int)
 U  = np.zeros((2*128,2*128), dtype=int)
 for i in range(100):
     iterate(Z)

--- a/scripts/glider-trace.py
+++ b/scripts/glider-trace.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
-# -----------------------------------------------------------------------------
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt

--- a/scripts/glider.py
+++ b/scripts/glider.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA
 # Contributors: Nicolas P. Rougier (Nicolas.Rougier@inria.fr)

--- a/scripts/glider.py
+++ b/scripts/glider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # -----------------------------------------------------------------------------
 # Copyright INRIA

--- a/scripts/gray-scott.py
+++ b/scripts/gray-scott.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 '''
 Reaction Diffusion : Gray-Scott model

--- a/scripts/gray-scott.py
+++ b/scripts/gray-scott.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 '''
 Reaction Diffusion : Gray-Scott model
 

--- a/scripts/gray-scott.py
+++ b/scripts/gray-scott.py
@@ -56,7 +56,7 @@ im = plt.imshow(V, interpolation='bicubic', cmap=plt.cm.gray_r)
 plt.xticks([]), plt.yticks([])
 
 
-for i in xrange(25000):
+for i in range(25000):
     Lu = (                 U[0:-2,1:-1] +
           U[1:-1,0:-2] - 4*U[1:-1,1:-1] + U[1:-1,2:] +
                            U[2:  ,1:-1] )

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -17,8 +17,8 @@ def compute_neighbours(Z):
 
 def show(Z):
     for l in Z[1:-1]:
-        print l[1:-1]
-    print
+        print(l[1:-1])
+    print()
 
 def iterate(Z):
     shape = len(Z), len(Z[0])


### PR DESCRIPTION
The matplotlib and 100 NumPy exercises seem to use the `print` statement, but for some reason, this one does not. A couple scripts require removing `xrange`, but otherwise they run fine on both 2 and 3.
