### PR TITLE
Remove pylab usage.

### DIFF
--- a/scripts/3d.py
+++ b/scripts/3d.py
@@ -1,24 +1,25 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_slice(Z, name):
     Z = np.atleast_2d(Z)
     rows,cols = Z.shape
-    fig = figure(figsize=(cols,rows), dpi=72, frameon=False)
-    #ax = subplot(111, frameon=False)
-    ax = axes([0,0,1,1], frameon=False)
+    fig = plt.figure(figsize=(cols,rows), dpi=72, frameon=False)
+    #ax = plt.subplot(111, frameon=False)
+    ax = plt.axes([0,0,1,1], frameon=False)
     A = np.arange(rows*cols).reshape(rows,cols)
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           vmin=0, vmax=max(1,Z.max()), interpolation='nearest', origin='upper')
-    #xticks(1.05+np.arange(cols-1),[]), yticks(1+np.arange(rows-1),[])
-    xticks([]), yticks([])
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               vmin=0, vmax=max(1,Z.max()), interpolation='nearest',
+               origin='upper')
+    #plt.xticks(1.05+np.arange(cols-1),[]), plt.yticks(1+np.arange(rows-1),[])
+    plt.xticks([]), plt.yticks([])
     #ax.grid(which='major', axis='x', linewidth=1.5, linestyle='-', color='w')
     #ax.grid(which='major', axis='y', linewidth=1.5, linestyle='-', color='w')
     #ax.tick_params(axis='x', colors='w')
     #ax.tick_params(axis='y', colors='w')
-    savefig('../figures/%s' % name, dpi=16)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=16)
+    #plt.show()
 
 
 rows,cols = 5, 9

--- a/scripts/broadcasts.py
+++ b/scripts/broadcasts.py
@@ -1,4 +1,5 @@
-from pylab import *
+import numpy as np
+import matplotlib.pyplot as plt
 from matplotlib.patches import Rectangle
 
 
@@ -25,7 +26,7 @@ def show(Z, shape, filename):
                          zorder=+10,edgecolor='black', alpha=.25,facecolor='None')
         ax.add_patch(rect)
         ax.set_axisbelow(True)
-    savefig(filename,dpi=72)
+    plt.savefig(filename,dpi=72)
 
 
 
@@ -83,29 +84,29 @@ show(Z1+Z2, Z.shape, "../figures/broadcast-4.5.png")
 #                 else:
 #                     color = 'k'
 #                     zorder=  +1
-#                 text(ox+x+0.5, rows-0.5-oy-y, '%d' % Z[y,x],
-#                      ha='center', va= 'center', size=24, color=color)    
+#                 plt.text(ox+x+0.5, rows-0.5-oy-y, '%d' % Z[y,x],
+#                          ha='center', va= 'center', size=24, color=color)
 #                 rect = Rectangle((ox+x,rows-1+oy-y),1,1, zorder=zorder,edgecolor=color, facecolor='None')
 #                 ax.add_patch(rect)
     
 #     rows = 4
 #     cols = 5*3 + (5-1)
-#     fig = figure(figsize=(cols,rows), dpi=72, frameon=False)
-#     ax = axes([0.05,0.05,.9,.9], frameon=False)
-#     xlim(0,cols), xticks([])
-#     ylim(0,rows), yticks([])
+#     fig = plt.figure(figsize=(cols,rows), dpi=72, frameon=False)
+#     ax = plt.axes([0.05,0.05,.9,.9], frameon=False)
+#     plt.xlim(0,cols), plt.xticks([])
+#     plt.ylim(0,rows), plt.yticks([])
 #     ox,oy = 0.0125, 0.0125
 #     print_array(Z1,ox+0,oy,Z1)
-#     text(3.5, 2, '+', ha='center', va= 'center', size=48)
+#     plt.text(3.5, 2, '+', ha='center', va= 'center', size=48)
 #     print_array(Z2,ox+4,oy,Z2)
-#     text(7.5, 2, '=', ha='center', va= 'center', size=48)
+#     plt.text(7.5, 2, '=', ha='center', va= 'center', size=48)
 #     print_array(Z3,ox+8,oy,Z1)
-#     text(11.5, 2, '+', ha='center', va= 'center', size=48)
+#     plt.text(11.5, 2, '+', ha='center', va= 'center', size=48)
 #     print_array(Z4,ox+12,oy,Z2)
-#     text(15.5, 2, '=', ha='center', va= 'center', size=48)
+#     plt.text(15.5, 2, '=', ha='center', va= 'center', size=48)
 #     print_array(Z5,ox+16,oy,Z5)
-# #    savefig('../figures/%s' % name, dpi=32)
-# #    show()
+# #    plt.savefig('../figures/%s' % name, dpi=32)
+# #    plt.show()
 
 
 

--- a/scripts/creates.py
+++ b/scripts/creates.py
@@ -1,38 +1,40 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_array2(Z, name):
     Z = np.atleast_2d(Z)
     rows,cols = Z.shape
-    fig = figure(figsize=(cols/4.,rows/4.), dpi=72)
+    fig = plt.figure(figsize=(cols/4.,rows/4.), dpi=72)
     ax = plt.subplot(111)
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           vmin=0, vmax=max(1,Z.max()), interpolation='nearest', origin='upper')
-    #xticks(1.05+np.arange(cols-1),[]), yticks(1+np.arange(rows-1),[])
-    xticks([]), yticks([])
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               vmin=0, vmax=max(1,Z.max()), interpolation='nearest',
+               origin='upper')
+    #plt.xticks(1.05+np.arange(cols-1),[]), plt.yticks(1+np.arange(rows-1),[])
+    plt.xticks([]), plt.yticks([])
     for pos in ['top', 'bottom', 'right', 'left']:
         ax.spines[pos].set_edgecolor('k')
         ax.spines[pos].set_alpha(.25)
-    savefig('../figures/%s' % name, dpi=72)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=72)
+    #plt.show()
 
 
 def show_array3(Z, name):
     Z = np.atleast_2d(Z)
     rows,cols = Z.shape[1],Z.shape[2]
-    fig = figure(figsize=(cols,rows), dpi=72, frameon=False)
+    fig = plt.figure(figsize=(cols,rows), dpi=72, frameon=False)
     for i in range(Z.shape[0],0,-1):
         d = .2*i/float(Z.shape[0])
-        ax = axes([d,d,0.7,0.7])
-        imshow(Z[Z.shape[0]-i], cmap='Purples', extent=[0,cols,0,rows],
-               vmin=0, vmax=max(1,Z.max()), interpolation='nearest', origin='upper')
-        xticks([]), yticks([])
+        ax = plt.axes([d,d,0.7,0.7])
+        plt.imshow(Z[Z.shape[0]-i], cmap='Purples', extent=[0,cols,0,rows],
+                   vmin=0, vmax=max(1,Z.max()), interpolation='nearest',
+                   origin='upper')
+        plt.xticks([]), plt.yticks([])
         for pos in ['top', 'bottom', 'right', 'left']:
             ax.spines[pos].set_edgecolor('k')
             ax.spines[pos].set_alpha(.25)
-    savefig('../figures/%s' % name, dpi=16)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=16)
+    #plt.show()
 
 
 

--- a/scripts/neighbours.py
+++ b/scripts/neighbours.py
@@ -1,24 +1,24 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_slice(Z, name, text=""):
     rows,cols = Z.shape
-    fig = figure(figsize=(cols/4.,rows/4.), dpi=72)
+    fig = plt.figure(figsize=(cols/4.,rows/4.), dpi=72)
     #fig.patch.set_alpha(0.0)
-    ax = subplot(111)
+    ax = plt.subplot(111)
     A = np.arange(rows*cols).reshape(rows,cols)
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           vmin=0, vmax=1, interpolation='nearest', origin='upper')
-    xticks([]), yticks([])
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               vmin=0, vmax=1, interpolation='nearest', origin='upper')
+    plt.xticks([]), plt.yticks([])
     for pos in ['top', 'bottom', 'right', 'left']:
         ax.spines[pos].set_edgecolor('k')
         ax.spines[pos].set_alpha(.25)
     if text:
         ax.text(cols/2.,-0.15,text,color='k',ha='center',va='top',
                 family='monospace', weight='bold',fontsize=10)
-    savefig('../figures/%s' % name, dpi=72)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=72)
+    #plt.show()
 
 rows,cols = 6, 6
 

--- a/scripts/operations.py
+++ b/scripts/operations.py
@@ -1,23 +1,23 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_array(Z, name):
 
     Z = np.atleast_2d(Z)
     rows,cols = Z.shape
-    fig = figure(figsize=(cols/4.,rows/4.), dpi=72)
+    fig = plt.figure(figsize=(cols/4.,rows/4.), dpi=72)
     ax = plt.subplot(111)
-    #imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-    #       vmin=-.2, vmax=1, interpolation='nearest', origin='upper')
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           interpolation='nearest', origin='upper')
-    xticks([]), yticks([])
+    #plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+    #           vmin=-.2, vmax=1, interpolation='nearest', origin='upper')
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               interpolation='nearest', origin='upper')
+    plt.xticks([]), plt.yticks([])
     for pos in ['top', 'bottom', 'right', 'left']:
         ax.spines[pos].set_edgecolor('k')
         ax.spines[pos].set_alpha(.25)
-    savefig('../figures/%s' % name, dpi=72)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=72)
+    #plt.show()
 
 
 rows,cols = 5, 9

--- a/scripts/reshapes.py
+++ b/scripts/reshapes.py
@@ -1,20 +1,20 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_slice(Z, name):
     rows,cols = Z.shape
-    fig = figure(figsize=(cols/4.,rows/4.), dpi=72)
-    ax = subplot(111)
+    fig = plt.figure(figsize=(cols/4.,rows/4.), dpi=72)
+    ax = plt.subplot(111)
     A = np.arange(rows*cols).reshape(rows,cols)
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           vmin=0, vmax=1, interpolation='nearest', origin='upper')
-    xticks([]), yticks([])
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               vmin=0, vmax=1, interpolation='nearest', origin='upper')
+    plt.xticks([]), plt.yticks([])
     for pos in ['top', 'bottom', 'right', 'left']:
         ax.spines[pos].set_edgecolor('k')
         ax.spines[pos].set_alpha(.25)
-    savefig('../figures/%s' % name, dpi=72)
-#    show()
+    plt.savefig('../figures/%s' % name, dpi=72)
+#    plt.show()
 
 
 rows,cols = 3, 4

--- a/scripts/slices.py
+++ b/scripts/slices.py
@@ -1,20 +1,20 @@
-from pylab import *
-from matplotlib.patches import Rectangle
+import numpy as np
+import matplotlib.pyplot as plt
 
 
 def show_slice(Z, name):
     rows,cols = Z.shape
-    fig = figure(figsize=(cols/4.,rows/4.), dpi=72)
-    ax = subplot(111)
+    fig = plt.figure(figsize=(cols/4.,rows/4.), dpi=72)
+    ax = plt.subplot(111)
     A = np.arange(rows*cols).reshape(rows,cols)
-    imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
-           vmin=0, vmax=1, interpolation='nearest', origin='upper')
-    xticks([]), yticks([])
+    plt.imshow(Z, cmap='Purples', extent=[0,cols,0,rows],
+               vmin=0, vmax=1, interpolation='nearest', origin='upper')
+    plt.xticks([]), plt.yticks([])
     for pos in ['top', 'bottom', 'right', 'left']:
         ax.spines[pos].set_edgecolor('k')
         ax.spines[pos].set_alpha(.25)
-    savefig('../figures/%s' % name, dpi=72)
-    #show()
+    plt.savefig('../figures/%s' % name, dpi=72)
+    #plt.show()
 
 
 


### PR DESCRIPTION
It's pretty obvious the perils of using `pylab` in scripts. All of them use `np.`, but half of them use bare matplotlib calls while the other half uses the `plt.` prefix.
